### PR TITLE
Fixed error occurring upon migration

### DIFF
--- a/web/Customer/migrations/0002_populate.py
+++ b/web/Customer/migrations/0002_populate.py
@@ -17,8 +17,8 @@ def populate_db(apps, schema_editor):
     new_admin = UserProfile.objects.get(pk=1)
     new_customer = UserProfile.objects.get(pk=2)
     
-    res1 = Reservation(car=car1, user=new_admin, startDate=start_date, endDate=end_date, renterID='id1')
-    res2 = Reservation(car=car2, user=new_customer, startDate=start_date, endDate=end_date, renterID='id2')
+    res1 = Reservation(car=car1, user=new_admin, startDate=start_date, endDate=end_date)
+    res2 = Reservation(car=car2, user=new_customer, startDate=start_date, endDate=end_date)
     res1.save()
     res2.save()
 


### PR DESCRIPTION
Fixed an error that was occurring when migrating. `renterID` was inluded in the populate file, but did not exist as a field in the Reservation model